### PR TITLE
Leagues serialize

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 
+gem 'active_model_serializers'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,11 @@ GEM
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
     active_designer (0.0.3)
+    active_model_serializers (0.10.12)
+      actionpack (>= 4.1, < 6.2)
+      activemodel (>= 4.1, < 6.2)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (6.1.3.2)
       activesupport (= 6.1.3.2)
       globalid (>= 0.3.6)
@@ -76,6 +81,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
@@ -88,6 +95,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    jsonapi-renderer (0.2.2)
     launchy (2.5.0)
       addressable (~> 2.7)
     listen (3.5.1)
@@ -217,6 +225,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_designer
+  active_model_serializers
   bootsnap (>= 1.4.4)
   byebug
   capybara

--- a/app/controllers/api/v1/leagues_controller.rb
+++ b/app/controllers/api/v1/leagues_controller.rb
@@ -2,7 +2,10 @@ class Api::V1::LeaguesController < ApiController
   before_action :find_league, except: [:index, :create]
 
   def index
-    render json: League.includes(seasons: [:teams]).all, include: '**', status: 200
+    render json: League.includes(seasons: [:teams]).all,
+      each_serializer: LeagueSerializer,
+      include: '**',
+      status: 200
   end
 
   def show

--- a/app/controllers/api/v1/leagues_controller.rb
+++ b/app/controllers/api/v1/leagues_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::LeaguesController < ApiController
   before_action :find_league, except: [:index, :create]
 
   def index
-    render json: League.all, status: 200
+    render json: League.includes(seasons: [:teams]).all, include: '**', status: 200
   end
 
   def show

--- a/app/serializers/league_serializer.rb
+++ b/app/serializers/league_serializer.rb
@@ -1,0 +1,4 @@
+class LeagueSerializer < ActiveModel::Serializer
+  attributes :id, :name
+  has_many :seasons
+end

--- a/app/serializers/season_serializer.rb
+++ b/app/serializers/season_serializer.rb
@@ -1,0 +1,4 @@
+class SeasonSerializer < ActiveModel::Serializer
+  attributes :id, :name
+  has_many :teams
+end

--- a/app/serializers/team_serializer.rb
+++ b/app/serializers/team_serializer.rb
@@ -1,0 +1,3 @@
+class TeamSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/spec/requests/api/v1/leagues/create_spec.rb
+++ b/spec/requests/api/v1/leagues/create_spec.rb
@@ -11,8 +11,6 @@ describe "Leagues API" do
 
     expect(response.status).to eq 201
     expect(league["name"]).to eq "BBAHL - C division"
-    expect(league["created_at"]).to be_a(String)
-    expect(league["updated_at"]).to be_a(String)
   end
 
   it "league name is required in payload" do

--- a/spec/requests/api/v1/leagues/index_spec.rb
+++ b/spec/requests/api/v1/leagues/index_spec.rb
@@ -3,14 +3,22 @@ require "rails_helper"
 describe "Leagues API" do
   it "/api/v1/leagues will return an array of hockey leagues" do
     league_1 = League.create!(name: "NHL")
+    season_1 = Season.create!(name: "2020-2021", league: league_1)
+    team_1 = Team.create!(name: "Colorado Avalanche", season: season_1)
+    team_2 = Team.create!(name: "Las Vegas Golden Knights", season: season_1)
     league_2 = League.create!(name: "AHL")
-    league_3 = League.create!(name: "BBAHL")
 
     get '/api/v1/leagues'
 
     leagues =  JSON.parse(response.body)
 
-    expect(leagues.count).to eq(3)
-    expect(leagues.first["name"]).to eq("NHL")
+    expect(leagues.count).to eq 2
+    expect(leagues.first["name"]).to eq "NHL"
+    expect(leagues.first["seasons"]).to be_a Array
+    expect(leagues.first["seasons"].first["name"]).to eq "2020-2021"
+    
+    avs, goons = leagues.first["seasons"].first["teams"]
+    expect(avs["name"]).to eq "Colorado Avalanche"
+    expect(goons["name"]).to eq "Las Vegas Golden Knights"
   end
 end


### PR DESCRIPTION
This adds some ActiveModelSerializers for League, Season, and Team models. Also does some eager loading of data. 

Learned that you can have multiple Serializers for one model, and you tell ActiveModelSerializer to recursively serialize all relationships (default it to go one level deep):

```
    render json: League.includes(seasons: [:teams]).all,
      each_serializer: LeagueSerializer,
      include: '**',
      status: 200
```